### PR TITLE
style: update stylelint configuration to have no selector-class-pattern rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,9 +1,10 @@
 {
 	"extends": ["stylelint-config-standard-scss"],
 	"rules": {
+		"selector-class-pattern": null,
 		"no-empty-source": null
 	},
-
+	"ignoreFiles": "dist/**",
 	"overrides": [
 		{
 			"files": ["*.html", "**/*.html"],


### PR DESCRIPTION
For Falko's snake_case :) now snake_case is no longer considered an error.

Also stylelint ignores all files in "dist".

